### PR TITLE
Alteração da função array_key_exists para property_exists

### DIFF
--- a/src/ZabbixApiAbstract.php
+++ b/src/ZabbixApiAbstract.php
@@ -285,7 +285,7 @@ abstract class ZabbixApiAbstract
         if (!is_object($this->responseDecoded) && !is_array($this->responseDecoded)) {
             throw new Exception('Could not decode JSON response.');
         }
-        if (array_key_exists('error', $this->responseDecoded)) {
+        if (property_exists($this->responseDecoded, 'error')) {
             throw new Exception('API error '.$this->responseDecoded->error->code.': '.$this->responseDecoded->error->data);
         }
 


### PR DESCRIPTION
no arquivo ZabbixApiAbstract.php, na linha 289, era usado a função "array_key_exists" para verificar se tinha erro.. Essa função está depreciada no php 7.4, impedindo que esse if seja verificado: 

" 
        if (array_key_exists('error', $this->responseDecoded)) {
            throw new Exception('API error '.$this->responseDecoded->error->code.': '.$this->responseDecoded->error->data);
        }
"

Portanto, foi alternado para a função "property_exists"...  o 'error' e a variável trocaram de posição devido a função ditar essa regra... e ficou assim:

" 
     if (property_exists($this->responseDecoded, 'error')) {
                 throw new Exception('API error '.$this->responseDecoded->error->code.': '.$this->responseDecoded->error->data);
     }
"







ToProperty_exists